### PR TITLE
Handle federated/SSO logins from Cognito

### DIFF
--- a/Provider/Settings.ascx
+++ b/Provider/Settings.ascx
@@ -76,6 +76,10 @@
     <asp:Label class="cognitoLabel" ID="lblLoginMessage" runat="server" Text="Login Message:" />
     <asp:TextBox class="cognitoTextbox" runat="server" ID="txtLoginMessage"></asp:TextBox>
 </div>
+<div class="dnnFormItem">
+    <asp:label class="cognitoLabel" id="lblHandleSSO" runat="server" Text="Handle SSO:"></asp:label>
+    <asp:CheckBox class="cognitoTextbox" Checked="true" runat="server" ID="chkHandleSSO"></asp:CheckBox>
+</div>
 
 
 

--- a/Provider/Settings.ascx.cs
+++ b/Provider/Settings.ascx.cs
@@ -36,6 +36,7 @@ namespace DNN.OpenId.Cognito
                 config.LoginMessage = txtLoginMessage.Text;
                 config.UseHostedUI = chkHostedUI.Checked;
                 config.CognitoDomain = txtCognitoDomain.Text;
+                config.HandleSSOLogins = chkHandleSSO.Checked;
 
                 DNNOpenIDCognitoConfig.UpdateConfig(config);
 
@@ -64,6 +65,7 @@ namespace DNN.OpenId.Cognito
                 txtCognitoPoolID.Text = config.CognitoPoolID;
                 txtLoginMessage.Text = config.LoginMessage;
                 txtCognitoDomain.Text = config.CognitoDomain;
+                chkHandleSSO.Checked = config.HandleSSOLogins;
             }
             catch (Exception exc)
             {
@@ -135,6 +137,10 @@ namespace DNN.OpenId.Cognito
                     LoginMessage = setting;
             }
             else { LoginMessage = "Your username will soon be migrated to the email address associated with your account. Please enter your email address and password"; }
+
+            setting = Null.NullString;
+            if (PortalController.Instance.GetPortalSettings(portalID).TryGetValue(PREFIX + "HandleSSOLogins", out setting))
+                HandleSSOLogins = bool.Parse(setting);
         }
 
         public bool Enabled { get; set; }
@@ -149,6 +155,8 @@ namespace DNN.OpenId.Cognito
         public bool UseHostedUI { get; set; }
         public string LoginMessage { get; set; }
         public string CognitoDomain { get; set; }
+
+        public bool HandleSSOLogins { get; set; }
 
 
 
@@ -172,6 +180,7 @@ namespace DNN.OpenId.Cognito
             PortalController.UpdatePortalSetting(config.PortalID, PREFIX + "UseHostedUI", config.UseHostedUI.ToString());
             PortalController.UpdatePortalSetting(config.PortalID, PREFIX + "LoginMessage", config.LoginMessage);
             PortalController.UpdatePortalSetting(config.PortalID, PREFIX + "CognitoDomain", config.CognitoDomain);
+            PortalController.UpdatePortalSetting(config.PortalID, PREFIX + "HandleSSOLogins", config.HandleSSOLogins.ToString());
 
         }
 

--- a/Provider/Settings.ascx.designer.cs
+++ b/Provider/Settings.ascx.designer.cs
@@ -229,5 +229,23 @@ namespace DNN.OpenId.Cognito
         /// To modify move field declaration from designer file to code-behind file.
         /// </remarks>
         protected global::System.Web.UI.WebControls.TextBox txtLoginMessage;
+
+        /// <summary>
+        /// lblHandleSSO control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.Label lblHandleSSO;
+
+        /// <summary>
+        /// chkHandleSSO control.
+        /// </summary>
+        /// <remarks>
+        /// Auto-generated field.
+        /// To modify move field declaration from designer file to code-behind file.
+        /// </remarks>
+        protected global::System.Web.UI.WebControls.CheckBox chkHandleSSO;
     }
 }


### PR DESCRIPTION
Added logic to handle federated logins from Cognito

Code changes added to the Authorize() method in login.ascx.cs

If (provider login).. // token has a separate claim for provider logins
   If (config.HandleSSO is true)
        check if DNNUser exists
          if yes, authorize the user to access LMS
          if not, create the user, and authorize the user to access LMS
